### PR TITLE
aw-mctl: allwinner memory controller driver (1/n)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "machine",
     "supervisor",
     "hal/d1-hal",
+    "hal/aw-mctl",
     "rom-rt",
     "rom-rt/macros",
     "xtask",

--- a/hal/aw-mctl/Cargo.toml
+++ b/hal/aw-mctl/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "aw-mctl"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+volatile-register = "0.2.1"
+
+[dev-dependencies]
+memoffset = "0.8"

--- a/hal/aw-mctl/README.md
+++ b/hal/aw-mctl/README.md
@@ -1,0 +1,5 @@
+# aw-mctl
+
+DDR memory driver for Allwinner chips.
+
+Ref: https://github.com/YuzukiHD/TinyKasKit

--- a/hal/aw-mctl/src/com.rs
+++ b/hal/aw-mctl/src/com.rs
@@ -1,0 +1,112 @@
+use volatile_register::RW;
+
+use super::COM;
+
+/// Common control peripheral
+pub struct RegisterBlock {
+    pub work_mode_0: RW<u32>, // 0x00
+    pub work_mode_1: RW<u32>, // 0x04
+    pub dbgcr: RW<u32>,       // 0x08
+    pub tmr: RW<u32>,         // 0x0c
+    _reserved0: [u32; 1],
+    pub cccr: RW<u32>, // 0x14
+    _reserved1: [u32; 2],
+    pub maer0: RW<u32>, // 0x20
+    pub maer1: RW<u32>, // 0x24
+    pub maer2: RW<u32>, // 0x28
+    _reserved2: [u32; 309],
+    pub remap0: RW<u32>, // 0x500
+    pub remap1: RW<u32>, // 0x504
+    pub remap2: RW<u32>, // 0x508
+    pub remap3: RW<u32>, // 0x50c
+}
+
+/// Dram type
+pub enum Type {
+    /// DDR2
+    Ddr2,
+    /// DDR3
+    Ddr3,
+    /// LPDDR2
+    LpDdr2,
+    /// LPDDR3
+    LpDdr3,
+}
+
+/// Dram configuration
+pub struct Config {
+    dram_type: Type,
+    unknown_tpr13_bit5: bool,
+    // rank: u8,
+}
+
+impl<const A: usize> COM<A> {
+    /// Configure dram settings
+    #[inline]
+    pub fn configure(&self, config: Config) {
+        let mut bits = 0;
+        let mut mask = 0;
+        let dram_type_bits = match config.dram_type {
+            Type::Ddr2 => 2,
+            Type::Ddr3 => 3,
+            Type::LpDdr2 => 6,
+            Type::LpDdr3 => 7,
+        };
+        bits |= dram_type_bits << 16;
+        mask |= 0xff << 16;
+        let dq_width = 1;
+        bits |= dq_width << 12;
+        mask |= 0x1 << 16;
+        let unknown1 = 1;
+        bits |= unknown1 << 22;
+        mask |= 0x1 << 22;
+        let unknown2 = match config.dram_type {
+            Type::LpDdr2 | Type::LpDdr3 => 1,
+            _ if config.unknown_tpr13_bit5 => 1,
+            _ => 0,
+        };
+        bits |= unknown2 << 19;
+        mask |= 0x1 << 19;
+        unsafe { self.work_mode_0.modify(|v| (v & !mask) | bits) };
+    }
+
+    /// Get DRAM size in bytes
+    #[inline]
+    pub fn dram_size(&self) -> usize {
+        let bits_0 = self.work_mode_0.read();
+        let bits_1 = self.work_mode_1.read();
+        fn rank_size_log2(bits: u32) -> u32 {
+            let page_size_bits = (bits >> 8) & 0xf;
+            let row_width_bits = (bits >> 4) & 0xf;
+            let bank_count_bits = (bits >> 2) & 0x3;
+            let page_size = page_size_bits + 3;
+            let row_width = row_width_bits + 1;
+            let bank_count = bank_count_bits + 2;
+            page_size + row_width + bank_count
+        }
+        let ans_rank_0 = rank_size_log2(bits_0);
+        let single_rank = (bits_0 & 0x3) == 0;
+        if single_rank {
+            return 1 << ans_rank_0;
+        }
+        let two_identical_ranks = (bits_1 & 0x3) == 0;
+        if two_identical_ranks {
+            return 1 << (ans_rank_0 + 1);
+        }
+        let ans_rank_1 = rank_size_log2(bits_1);
+        1 << (ans_rank_0 + ans_rank_1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RegisterBlock;
+    use memoffset::offset_of;
+    #[test]
+    fn offset_com() {
+        assert_eq!(offset_of!(RegisterBlock, tmr), 0x0c);
+        assert_eq!(offset_of!(RegisterBlock, cccr), 0x14);
+        assert_eq!(offset_of!(RegisterBlock, maer0), 0x20);
+        assert_eq!(offset_of!(RegisterBlock, remap0), 0x500);
+    }
+}

--- a/hal/aw-mctl/src/lib.rs
+++ b/hal/aw-mctl/src/lib.rs
@@ -1,0 +1,38 @@
+#![no_std]
+
+pub mod com;
+pub mod phy;
+
+use core::{marker::PhantomData, ops};
+
+/// Common control peripheral
+pub struct COM<const A: usize> {
+    _marker: PhantomData<*const ()>,
+}
+
+unsafe impl<const A: usize> Send for COM<A> {}
+
+impl<const A: usize> ops::Deref for COM<A> {
+    type Target = com::RegisterBlock;
+
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*(A as *const _) }
+    }
+}
+
+/// Physical layer peripheral
+pub struct PHY<const A: usize> {
+    _marker: PhantomData<*const ()>,
+}
+
+unsafe impl<const A: usize> Send for PHY<A> {}
+
+impl<const A: usize> ops::Deref for PHY<A> {
+    type Target = phy::RegisterBlock;
+
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*(A as *const _) }
+    }
+}

--- a/hal/aw-mctl/src/phy.rs
+++ b/hal/aw-mctl/src/phy.rs
@@ -1,0 +1,152 @@
+use volatile_register::{RO, RW};
+
+use super::PHY;
+
+/// Physical layer peripheral
+// Ref: https://github.com/Moxa-Linux/BIOS-UC-8200_source_code/blob/master/arch/arm/include/asm/arch-sunxi/dram_sun8i_h3.h
+#[repr(C)]
+pub struct RegisterBlock {
+    /// PHY initialization register
+    pub pir: RW<u32>, // 0x00
+    pub pwrctl: RW<u32>,  // 0x04
+    pub mrctrl0: RW<u32>, // 0x08
+    pub clken: RW<u32>,   // 0x0c
+    /// PHY general status registers
+    pub pgsr: [RW<u32>; 2], // 0x10 ..= 0x14
+    pub statr: RW<u32>,   // 0x18
+    _reserved0: [u32; 4],
+    pub lp3mr11: RW<u32>, // 0x2c
+    /// mode registers
+    pub mr: [RW<u32>; 4], // 0x30 ..= 0x3c
+    _reserved1: [u32; 1],
+    /// PHY timing registers
+    pub ptr: [RW<u32>; 5], // 0x44 ..= 0x54
+    /// DRAM timing registers
+    pub dramtmg: [RW<u32>; 9], // 0x58 ..= 0x78
+    pub odtcfg: RW<u32>, // 0x7c
+    /// PHY interface timing registers
+    pub pitmg: [RW<u32>; 2], // 0x80 ..= 0x84
+    pub lptpr: RW<u32>,  // 0x88
+    pub rfshctl0: RW<u32>, // 0x8c
+    /// refresh timing
+    pub rfshtmg: RW<u32>, // 0x90
+    pub rfshctl1: RW<u32>, // 0x94
+    pub pwrtmg: RW<u32>, // 0x98
+    pub asrc: RW<u32>,   // 0x9c
+    pub asrtc: RW<u32>,  // 0xa0
+    _reserved3: [u32; 5],
+    pub vtfcr: RW<u32>,  // 0xb8
+    pub dqsgmr: RW<u32>, // 0xbc
+    pub dtcr: RW<u32>,   // 0xc0
+    pub dtar0: RW<u32>,  // 0xc4
+    _reserved4: [u32; 14],
+    /// PHY general configuration registers
+    pub pgcr: [RW<u32>; 4], // 0x100 ..= 0x10c
+    pub iovcr0: RW<u32>, // 0x110
+    pub iovcr1: RW<u32>, // 0x114
+    _reserved5: [u32; 1],
+    pub dxccr: RW<u32>,      // 0x11c
+    pub odtmap: RW<u32>,     // 0x120
+    pub zqctl: [RW<u32>; 2], // 0x124 ..= 0x128
+    _reserved6: [u32; 5],
+    /// ZQ control register
+    pub zqcr: RW<u32>, // 0x140
+    /// ZQ status register
+    pub zqsr: RW<u32>, // 0x144
+    /// ZQ data registers
+    pub zqdr: [RW<u32>; 3], // 0x148 ..= 0x150
+    _reserved7: [u32; 27],
+    pub sched: RW<u32>,        // 0x1c0
+    pub perfhpr: [RW<u32>; 2], // 0x1c4 ..= 0x1c8
+    pub perflpr: [RW<u32>; 2], // 0x1cc ..= 0x1d0
+    pub perfwr: [RW<u32>; 2],  // 0x1d4 ..= 0x1d8
+    _reserved8: [u32; 9],
+    pub acmdlr: RW<u32>,  // 0x200
+    pub acldlr: RW<u32>,  // 0x204
+    pub aciocr0: RW<u32>, // 0x208
+    _reserved9: [u32; 61],
+    pub datx: [Datx8; 4], // 0x300 ..= 0x4fc
+    _reserved10: [u32; 226],
+    pub upd2: RW<u32>, // 0x888
+}
+
+/// DATX8 register group
+#[repr(C)]
+pub struct Datx8 {
+    pub mdlr: RW<u32>,       // 0x00
+    pub lcdlr: [RW<u32>; 3], // 0x04 ..= 0x0c
+    /// IO configuration register
+    pub iocr: [RW<u32>; 11], // 0x10 ..= 0x38
+    pub sdlr6: RW<u32>,      // 0x3c
+    pub gtr: RW<u32>,        // 0x40
+    pub gcr: RW<u32>,        // 0x44
+    pub gsr0: RO<u32>,       // 0x48
+    pub gsr1: RW<u32>,       // 0x4c
+    pub gsr2: RW<u32>,       // 0x50
+    _reserved0: [u32; 11],
+}
+
+/// Data pin width
+pub enum DqWidth {
+    /// Half DQ width
+    X8,
+    /// Full DQ width
+    X16,
+}
+
+impl<const A: usize> PHY<A> {
+    #[inline]
+    pub fn dqs_gate_detect(&self) {
+        let pgsr0 = self.pgsr[0].read();
+        let qsgerr = pgsr0 & (1 << 22) != 0;
+        if !qsgerr {
+            // dual rank, full DQ
+            return;
+        }
+        let dx0_gsr0 = self.datx[0].gsr0.read();
+        let dx1_gsr0 = self.datx[1].gsr0.read();
+        // qsgerr; each bit for one rank
+        let dx0_qsgerr = (dx0_gsr0 >> 26) & 0xf;
+        let dx1_qsgerr = (dx1_gsr0 >> 26) & 0xf;
+        if dx0_qsgerr & 0x2 != 0 {
+            if dx1_qsgerr & 0x2 != 0 {
+                // single rank, full DQ
+                return;
+            } else {
+                // single rank, half DQ
+                return;
+            }
+        } else {
+            if dx1_qsgerr != 0 {
+                // todo
+            } else {
+                // dual rank, half DQ
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Datx8, RegisterBlock};
+    use memoffset::offset_of;
+    #[test]
+    fn offset_phy() {
+        assert_eq!(offset_of!(RegisterBlock, lp3mr11), 0x2c);
+        assert_eq!(offset_of!(RegisterBlock, ptr), 0x44);
+        assert_eq!(offset_of!(RegisterBlock, pgcr), 0x100);
+        assert_eq!(offset_of!(RegisterBlock, zqcr), 0x140);
+        assert_eq!(offset_of!(RegisterBlock, sched), 0x1c0);
+        assert_eq!(offset_of!(RegisterBlock, acmdlr), 0x200);
+        assert_eq!(offset_of!(RegisterBlock, datx), 0x300);
+        assert_eq!(offset_of!(RegisterBlock, upd2), 0x888);
+    }
+    #[test]
+    fn offset_datx8() {
+        assert_eq!(offset_of!(Datx8, mdlr), 0x00);
+        assert_eq!(offset_of!(Datx8, lcdlr), 0x04);
+        assert_eq!(offset_of!(Datx8, iocr), 0x10);
+        assert_eq!(offset_of!(Datx8, sdlr6), 0x3c);
+        assert_eq!(offset_of!(Datx8, gsr0), 0x48);
+    }
+}


### PR DESCRIPTION
结构化的allwinner mctl驱动（DDR控制器驱动）的第一部分。这个包目前放在原型系统项目里，以后可能会独立为单独的项目。

DDR有关的驱动不得不说难度太大了，先做框架在这里，后续再继续更新。

Thanks to @dramforever for detailed ideas.