### PR TITLE
aw-soc: spi: create Spi struct and minor fixes

### DIFF
--- a/hal/aw-soc/Cargo.toml
+++ b/hal/aw-soc/Cargo.toml
@@ -11,7 +11,7 @@ base-address = "0.0.0"
 embedded-hal = "1.0.0-alpha.9"
 embedded-hal-nb = "1.0.0-alpha.1"
 nb = "1"
-uart16550 = "0.0.0"
+uart16550 = "0.0.1"
 
 [dev-dependencies]
 memoffset = "0.8"

--- a/hal/aw-soc/src/ccu.rs
+++ b/hal/aw-soc/src/ccu.rs
@@ -20,9 +20,29 @@ pub struct RegisterBlock {
     _reserved0: [u32; 579],
     /// 0x90c - UART Bus Gating Reset register.
     pub uart_bgr: UART_BGR,
+    _reserved1: [u32; 12],
+    /// 0x940..=0x944 - SPI0 Clock Register and SPI1 Clock Register.
+    pub spi_clk: [SPI_CLK; 2],
+    _reserved2: [u32; 9],
+    /// 0x96c - SPI Bus Gating Reset register.
+    pub spi_bgr: SPI_BGR,
+}
+
+/// Clock divide factor N.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum FactorN {
+    /// Don't divide.
+    N1,
+    /// Divide frequency by 2.
+    N2,
+    /// Divide frequency by 4.
+    N4,
+    /// Divide frequency by 8.
+    N8,
 }
 
 /// UART Bus Gating Reset register.
+#[allow(non_camel_case_types)]
 #[repr(C)]
 pub struct UART_BGR(UnsafeCell<u32>);
 
@@ -44,6 +64,7 @@ mod uart_bgr {
     }
 
     /// Structure representation of UART bus gating register.
+    #[repr(transparent)]
     pub struct UartBgr(u32);
 
     impl UartBgr {
@@ -69,6 +90,167 @@ mod uart_bgr {
         }
     }
 }
+
+pub use uart_bgr::UartBgr;
+
+/// SPI Clock Register.
+#[repr(C)]
+#[allow(non_camel_case_types)]
+pub struct SPI_CLK(UnsafeCell<u32>);
+
+mod spi_clk {
+    use super::{FactorN, SPI_CLK};
+
+    impl SPI_CLK {
+        /// Write settings to SPI clock register.
+        #[inline]
+        pub fn write(&self, val: SpiClk) {
+            unsafe { self.0.get().write_volatile(val.0) }
+        }
+
+        /// Read settings from SPI clock register.
+        #[inline]
+        pub fn read(&self) -> SpiClk {
+            SpiClk(unsafe { self.0.get().read_volatile() })
+        }
+    }
+
+    /// Structure representation of SPI clock register.
+    #[repr(transparent)]
+    pub struct SpiClk(u32);
+
+    impl SpiClk {
+        const CLK_SRC_SEL: u32 = 0x7 << 24;
+        const FACTOR_N: u32 = 0x3 << 8;
+        const FACTOR_M: u32 = 0xf << 0;
+
+        /// Get SPI clock source.
+        #[inline]
+        pub const fn clock_source(self) -> ClockSource {
+            match (self.0 & Self::CLK_SRC_SEL) >> 24 {
+                0x0 => ClockSource::Hosc,
+                0x1 => ClockSource::PllPeri1x,
+                0x2 => ClockSource::PllPeri2x,
+                0x3 => ClockSource::PllAudio1Div2,
+                0x4 => ClockSource::PllAudio1Div5,
+                _ => panic!("impossible clock source"),
+            }
+        }
+        /// Set SPI clock source.
+        #[inline]
+        pub const fn set_clock_source(self, val: ClockSource) -> Self {
+            let val = match val {
+                ClockSource::Hosc => 0x0,
+                ClockSource::PllPeri1x => 0x1,
+                ClockSource::PllPeri2x => 0x2,
+                ClockSource::PllAudio1Div2 => 0x3,
+                ClockSource::PllAudio1Div5 => 0x4,
+            };
+            Self((self.0 & !Self::CLK_SRC_SEL) | (val << 24))
+        }
+        /// Get SPI clock divide factor N.
+        #[inline]
+        pub const fn factor_n(self) -> FactorN {
+            match (self.0 & Self::FACTOR_N) >> 8 {
+                0 => FactorN::N1,
+                1 => FactorN::N2,
+                2 => FactorN::N4,
+                3 => FactorN::N8,
+                _ => unreachable!(),
+            }
+        }
+        /// Set SPI clock divide factor N.
+        #[inline]
+        pub const fn set_factor_n(self, val: FactorN) -> Self {
+            let val = match val {
+                FactorN::N1 => 0,
+                FactorN::N2 => 1,
+                FactorN::N4 => 2,
+                FactorN::N8 => 3,
+            };
+            Self((self.0 & !Self::FACTOR_N) | (val << 8))
+        }
+        /// Get SPI clock divide factor M.
+        #[inline]
+        pub const fn factor_m(self) -> u8 {
+            (self.0 & Self::FACTOR_M) as u8
+        }
+        /// Set SPI clock divide factor M.
+        #[inline]
+        pub const fn set_factor_m(self, val: u8) -> Self {
+            Self((self.0 & !Self::FACTOR_M) | val as u32)
+        }
+    }
+
+    /// SPI clock source.
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    pub enum ClockSource {
+        /// HOSC.
+        Hosc,
+        /// Peripheral PLL (1x).
+        PllPeri1x,
+        /// Peripheral PLL (2x).
+        PllPeri2x,
+        /// Audio PLL (div 2).
+        PllAudio1Div2,
+        /// Audio PLL (div 5).
+        PllAudio1Div5,
+    }
+}
+
+pub use spi_clk::{ClockSource as SpiClockSource, SpiClk};
+
+/// SPI Bus Gating Reset register.
+#[allow(non_camel_case_types)]
+#[repr(C)]
+pub struct SPI_BGR(UnsafeCell<u32>);
+
+mod spi_bgr {
+    use super::SPI_BGR;
+
+    impl SPI_BGR {
+        /// Write settings to SPI bus gating register.
+        #[inline]
+        pub fn write(&self, val: SpiBgr) {
+            unsafe { self.0.get().write_volatile(val.0) }
+        }
+
+        /// Read settings from SPI bus gating register.
+        #[inline]
+        pub fn read(&self) -> SpiBgr {
+            SpiBgr(unsafe { self.0.get().read_volatile() })
+        }
+    }
+
+    /// Structure representation of SPI bus gating register.
+    #[repr(transparent)]
+    pub struct SpiBgr(u32);
+
+    impl SpiBgr {
+        /// Disable clock gate for SPI `I`.
+        #[inline]
+        pub fn gate_mask<const I: usize>(self) -> Self {
+            Self(self.0 & !(1 << I))
+        }
+        /// Enable clock gate for SPI `I`.
+        #[inline]
+        pub fn gate_pass<const I: usize>(self) -> Self {
+            Self(self.0 | (1 << I))
+        }
+        /// Assert reset signal for SPI `I`.
+        #[inline]
+        pub fn assert_reset<const I: usize>(self) -> Self {
+            Self(self.0 & !(1 << (I + 16)))
+        }
+        /// Deassert reset signal for SPI `I`.
+        #[inline]
+        pub fn deassert_reset<const I: usize>(self) -> Self {
+            Self(self.0 | (1 << (I + 16)))
+        }
+    }
+}
+
+pub use spi_bgr::SpiBgr;
 
 impl<const B: usize> CCU<Static<B>> {
     /// Create a peripheral instance from statically known address.
@@ -96,12 +278,27 @@ impl CCU<Dynamic> {
     }
 }
 
-/// Static peripheral that can be clock gated by CCU.
+/// Peripheral that can be clock gated by CCU.
 pub trait ClockGate {
     /// Reset this peripheral by provided `ccu`.
     unsafe fn reset<A: BaseAddress>(ccu: &CCU<A>);
     /// Free this peripheral by provided `ccu`.
     unsafe fn free<A: BaseAddress>(ccu: &CCU<A>);
+}
+
+/// Peripheral whose clock can be configurated by CCU.
+pub trait ClockConfig {
+    /// Type of clock source.
+    type Source;
+    /// Configure peripheral clock.
+    ///
+    /// Value `factor_m` should be in 0 ..= 15.
+    unsafe fn config<A: BaseAddress>(
+        source: Self::Source,
+        factor_m: u8,
+        factor_n: FactorN,
+        ccu: &CCU<A>,
+    );
 }
 
 /// Universal Asynchronous Receiver-Transmitter clock gate.
@@ -128,6 +325,47 @@ impl<const I: usize> ClockGate for UART<I> {
     }
 }
 
+/// Serial Peripheral Interface clock gate.
+pub struct SPI<const IDX: usize>;
+
+impl<const I: usize> ClockGate for SPI<I> {
+    #[inline]
+    unsafe fn reset<A: BaseAddress>(ccu: &CCU<A>) {
+        let spi_bgr = ccu.spi_bgr.read();
+        ccu.spi_bgr
+            .write(spi_bgr.gate_mask::<I>().assert_reset::<I>());
+        let spi_bgr = ccu.spi_bgr.read();
+        ccu.spi_bgr
+            .write(spi_bgr.gate_pass::<I>().deassert_reset::<I>());
+    }
+
+    #[inline]
+    unsafe fn free<A: BaseAddress>(ccu: &CCU<A>) {
+        let spi_bgr = ccu.spi_bgr.read();
+        ccu.spi_bgr
+            .write(spi_bgr.gate_mask::<I>().assert_reset::<I>());
+    }
+}
+
+impl<const I: usize> ClockConfig for SPI<I> {
+    type Source = SpiClockSource;
+
+    unsafe fn config<A: BaseAddress>(
+        source: Self::Source,
+        factor_m: u8,
+        factor_n: FactorN,
+        ccu: &CCU<A>,
+    ) {
+        let spi_clk = ccu.spi_clk[I].read();
+        ccu.spi_clk[I].write(
+            spi_clk
+                .set_clock_source(source)
+                .set_factor_m(factor_m)
+                .set_factor_n(factor_n),
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::RegisterBlock;
@@ -135,5 +373,7 @@ mod tests {
     #[test]
     fn offset_ccu() {
         assert_eq!(offset_of!(RegisterBlock, uart_bgr), 0x90c);
+        assert_eq!(offset_of!(RegisterBlock, spi_clk), 0x940);
+        assert_eq!(offset_of!(RegisterBlock, spi_bgr), 0x96c);
     }
 }

--- a/hal/aw-soc/src/gpio.rs
+++ b/hal/aw-soc/src/gpio.rs
@@ -212,6 +212,7 @@ impl<A: BaseAddress, const P: char, const N: u8> EintPin for Pin<A, P, N, EintMo
     }
 }
 
+#[allow(unused)]
 macro_rules! impl_gpio_pins {
     ($($px: ident:($P: expr, $N: expr, $M: ty);)+) => {
 /// GPIO pins in current platform.

--- a/hal/aw-soc/src/lib.rs
+++ b/hal/aw-soc/src/lib.rs
@@ -147,6 +147,7 @@ pub mod time {
 }
 
 mod wafer {
+    #[cfg(feature = "d1")]
     mod d1;
     pub mod prelude {
         #[cfg(feature = "d1")]

--- a/hal/aw-soc/src/spi.rs
+++ b/hal/aw-soc/src/spi.rs
@@ -1,26 +1,34 @@
 //! Serial Peripheral Interface bus
 
 use super::SPI;
+use crate::{
+    ccu::{self, ClockConfig, ClockGate, Clocks, FactorN, SpiClockSource},
+    time::Hz,
+    CCU,
+};
 use base_address::{BaseAddress, Dynamic, Static};
+use core::cell::UnsafeCell;
+use embedded_hal::spi::Mode;
 use volatile_register::RW;
 
+/// Serial Peripheral Interface registers.
 #[repr(C)]
 pub struct RegisterBlock {
     _reserved0: u32,
-    pub gcr: RW<u32>,
-    pub tcr: RW<u32>,
+    pub gcr: GCR,
+    pub tcr: TCR,
     _reserved1: u32,
     pub ier: RW<u32>,
     pub isr: RW<u32>,
     pub fcr: RW<u32>,
-    pub fsr: RW<u32>,
+    pub fsr: FSR,
     pub wcr: RW<u32>,
     _reserved2: u32,
     pub samp_dl: RW<u32>,
     _reserved3: u32,
-    pub mbc: RW<u32>,
-    pub mtc: RW<u32>,
-    pub bcc: RW<u32>,
+    pub mbc: MBC,
+    pub mtc: MTC,
+    pub bcc: BCC,
     _reserved4: u32,
     pub batcr: RW<u32>,
     pub ba_ccr: RW<u32>,
@@ -29,9 +37,9 @@ pub struct RegisterBlock {
     _reserved5: [u32; 14],
     pub ndma_mode_ctl: RW<u32>,
     _reserved6: [u32; 93],
-    pub txd: RW<u32>,
+    pub txd: TXD,
     _reserved7: [u32; 63],
-    pub rxd: RW<u32>,
+    pub rxd: RXD,
 }
 
 impl<const B: usize> SPI<Static<B>> {
@@ -60,45 +68,549 @@ impl SPI<Dynamic> {
     }
 }
 
-pub struct Spi<A: BaseAddress, PINS> {
+/// Global control register.
+#[repr(transparent)]
+pub struct GCR(UnsafeCell<u32>);
+
+impl GCR {
+    /// Read global control.
+    #[inline]
+    pub fn read(&self) -> GlobalControl {
+        GlobalControl(unsafe { self.0.get().read_volatile() })
+    }
+    /// Write global control.
+    #[inline]
+    pub fn write(&self, val: GlobalControl) {
+        unsafe { self.0.get().write_volatile(val.0) }
+    }
+}
+
+/// Global control for current peripheral.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+#[repr(transparent)]
+pub struct GlobalControl(u32);
+
+impl GlobalControl {
+    const SRST: u32 = 1 << 31;
+    const TP_EN: u32 = 1 << 7;
+    // const MODE_SELEC: u32 = 1 << 2;
+    const MODE: u32 = 1 << 1;
+    const EN: u32 = 1 << 0;
+    /// Perform software reset to the SPI controller.
+    #[inline]
+    pub const fn software_reset(self) -> Self {
+        Self(self.0 | Self::SRST)
+    }
+    /// Check if software reset request has finished.
+    #[inline]
+    pub const fn is_software_reset_finished(self) -> bool {
+        self.0 & Self::SRST != 0
+    }
+    /// Set transmit pause enable flag.
+    ///
+    /// In master mode, if this flag is enabled, transmitting data will be
+    /// stopped when receive FIFO is full.
+    #[inline]
+    pub const fn set_transmit_pause_enable(self, val: bool) -> Self {
+        Self((self.0 & !Self::TP_EN) | if val { Self::TP_EN } else { 0 })
+    }
+    /// Check if transmit pause has enabled.
+    #[inline]
+    pub const fn transmit_pause_enabled(self) -> bool {
+        self.0 & Self::TP_EN != 0
+    }
+    /// Set this peripheral to operate on master mode.
+    #[inline]
+    pub const fn set_master_mode(self) -> Self {
+        Self(self.0 | Self::MODE)
+    }
+    /// Set this peripheral to operate on slave mode.
+    #[inline]
+    pub const fn set_slave_mode(self) -> Self {
+        Self(self.0 & !Self::MODE)
+    }
+    /// Check if this peripheral operates on master mode.
+    #[inline]
+    pub const fn is_master_mode(self) -> bool {
+        self.0 & Self::MODE != 0
+    }
+    /// Check if this peripheral operates on slave mode.
+    #[inline]
+    pub const fn is_slave_mode(self) -> bool {
+        self.0 & Self::MODE == 0
+    }
+    /// Enable or disable this peripheral.
+    #[inline]
+    pub const fn set_enabled(self, val: bool) -> Self {
+        Self((self.0 & !Self::EN) | if val { Self::EN } else { 0 })
+    }
+    /// Check if this peripheral is enabled.
+    #[inline]
+    pub const fn is_enabled(self) -> bool {
+        self.0 & Self::EN != 0
+    }
+}
+
+/// Transfer control register.
+#[repr(transparent)]
+pub struct TCR(UnsafeCell<u32>);
+
+impl TCR {
+    /// Read transfer control.
+    #[inline]
+    pub fn read(&self) -> TransferControl {
+        TransferControl(unsafe { self.0.get().read_volatile() })
+    }
+    /// Write transfer control.
+    #[inline]
+    pub fn write(&self, val: TransferControl) {
+        unsafe { self.0.get().write_volatile(val.0) }
+    }
+}
+
+/// Transfer control for current peripheral.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+#[repr(transparent)]
+pub struct TransferControl(u32);
+
+impl TransferControl {
+    const XCH: u32 = 1 << 31;
+    const CPOL: u32 = 1 << 1;
+    const CPHA: u32 = 1 << 0;
+    /// Check if burst exchange has finished.
+    #[inline]
+    pub const fn burst_finished(self) -> bool {
+        self.0 & Self::XCH == 0
+    }
+    /// Initiates burst exchange.
+    #[inline]
+    pub const fn start_burst_exchange(self) -> Self {
+        Self(self.0 | Self::XCH)
+    }
+    /// Sets SPI work mode.
+    #[inline]
+    pub const fn set_work_mode(self, mode: Mode) -> Self {
+        use embedded_hal::spi::{Phase, Polarity};
+        let mut bits = self.0;
+        match mode.polarity {
+            Polarity::IdleLow => bits &= !Self::CPOL,
+            Polarity::IdleHigh => bits |= Self::CPOL,
+        }
+        match mode.phase {
+            Phase::CaptureOnFirstTransition => bits &= !Self::CPHA,
+            Phase::CaptureOnSecondTransition => bits |= Self::CPHA,
+        }
+        Self(bits)
+    }
+}
+
+/// FIFO status register.
+#[repr(transparent)]
+pub struct FSR(UnsafeCell<u32>);
+
+impl FSR {
+    /// Read FIFO status.
+    #[inline]
+    pub fn read(&self) -> FifoStatus {
+        FifoStatus(unsafe { self.0.get().read_volatile() })
+    }
+}
+
+/// Status of FIFO for current peripheral.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct FifoStatus(u32);
+
+impl FifoStatus {
+    const TB_WR: u32 = 0x1 << 31;
+    const TB_CNT: u32 = 0x7 << 28;
+    const TF_CNT: u32 = 0xff << 16;
+    const RB_WR: u32 = 0x1 << 15;
+    const RB_CNT: u32 = 0x7 << 12;
+    const RF_CNT: u32 = 0xff << 0;
+
+    #[inline]
+    pub const fn transmit_buffer_write_enable(self) -> bool {
+        self.0 & Self::TB_WR != 0
+    }
+
+    #[inline]
+    pub const fn transmit_buffer_counter(self) -> u8 {
+        ((self.0 & Self::TB_CNT) >> 28) as u8
+    }
+
+    #[inline]
+    pub const fn transmit_fifo_counter(self) -> u8 {
+        ((self.0 & Self::TF_CNT) >> 16) as u8
+    }
+
+    #[inline]
+    pub const fn receive_buffer_write_enable(self) -> bool {
+        self.0 & Self::RB_WR != 0
+    }
+
+    #[inline]
+    pub const fn receive_buffer_counter(self) -> u8 {
+        ((self.0 & Self::RB_CNT) >> 12) as u8
+    }
+
+    #[inline]
+    pub const fn receive_fifo_counter(self) -> u8 {
+        (self.0 & Self::RF_CNT) as u8
+    }
+}
+
+/// Master burst counter register.
+///
+/// In master mode, this field specifies the total burst number.
+/// The totcal transfer data include transmit, receive parts and
+/// dummy burst.
+#[repr(transparent)]
+pub struct MBC(UnsafeCell<u32>);
+
+impl MBC {
+    /// Read master burst counter.
+    #[inline]
+    pub fn read(&self) -> u32 {
+        unsafe { self.0.get().read_volatile() }
+    }
+    /// Write master burst counter.
+    #[inline]
+    pub fn write(&self, val: u32) {
+        unsafe { self.0.get().write_volatile(val) }
+    }
+}
+
+/// Master transmit counter register.
+#[repr(transparent)]
+pub struct MTC(UnsafeCell<u32>);
+
+impl MTC {
+    /// Read master transmit counter.
+    #[inline]
+    pub fn read(&self) -> u32 {
+        unsafe { self.0.get().read_volatile() }
+    }
+    /// Write master transmit counter.
+    #[inline]
+    pub fn write(&self, val: u32) {
+        unsafe { self.0.get().write_volatile(val) }
+    }
+}
+
+/// Burst control counter register.
+#[repr(transparent)]
+pub struct BCC(UnsafeCell<u32>);
+
+impl BCC {
+    /// Read burst control counter.
+    #[inline]
+    pub fn read(&self) -> BurstControl {
+        BurstControl(unsafe { self.0.get().read_volatile() })
+    }
+    /// Write burst control counter.
+    #[inline]
+    pub fn write(&self, val: BurstControl) {
+        unsafe { self.0.get().write_volatile(val.0) }
+    }
+}
+
+/// Burst control counter for current peripheral.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct BurstControl(u32);
+
+impl BurstControl {
+    const QUAD_EN: u32 = 0x1 << 29;
+    // const DRM: u32 = 0x1 << 28;
+    const DBC: u32 = 0xf << 24;
+    const STC: u32 = 0xfff << 0;
+    /// Enable quad mode.
+    #[inline]
+    pub const fn quad_mode_enable(self) -> Self {
+        Self(self.0 | Self::QUAD_EN)
+    }
+    /// Disable quad mode.
+    #[inline]
+    pub const fn quad_mode_disable(self) -> Self {
+        Self(self.0 & !Self::QUAD_EN)
+    }
+    /// Check if quad mode is enabled.
+    #[inline]
+    pub const fn is_quad_mode_enabled(self) -> bool {
+        self.0 & Self::QUAD_EN != 0
+    }
+
+    #[inline]
+    pub const fn master_dummy_burst_counter(self) -> u8 {
+        ((self.0 & Self::DBC) >> 24) as u8
+    }
+
+    #[inline]
+    pub const fn set_master_dummy_burst_counter(self, val: u8) -> Self {
+        Self((self.0 & !Self::DBC) | ((val as u32 & 0xf) << 24))
+    }
+
+    #[inline]
+    pub const fn master_single_mode_transmit_counter(self) -> u32 {
+        self.0 & Self::STC
+    }
+
+    #[inline]
+    pub const fn set_master_single_mode_transmit_counter(self, val: u32) -> Self {
+        Self((self.0 & !Self::STC) | (val & 0xfff))
+    }
+}
+
+/// Transmit data register.
+#[repr(transparent)]
+pub struct TXD(UnsafeCell<u32>);
+
+impl TXD {
+    /// Write 8-bit data.
+    #[inline]
+    pub fn write_u8(&self, val: u8) {
+        unsafe { (self.0.get() as *mut u8).write_volatile(val) }
+    }
+    /// Write 16-bit data.
+    #[inline]
+    pub fn write_u16(&self, val: u16) {
+        unsafe { (self.0.get() as *mut u16).write_volatile(val) }
+    }
+    /// Write 32-bit data.
+    #[inline]
+    pub fn write_u32(&self, val: u32) {
+        unsafe { self.0.get().write_volatile(val) }
+    }
+}
+
+/// Receive data register.
+#[repr(transparent)]
+pub struct RXD(UnsafeCell<u32>);
+
+impl RXD {
+    /// Read 8-bit data.
+    #[inline]
+    pub fn read_u8(&self) -> u8 {
+        unsafe { (self.0.get() as *const u8).read_volatile() }
+    }
+    /// Read 16-bit data.
+    #[inline]
+    pub fn read_u16(&self) -> u16 {
+        unsafe { (self.0.get() as *const u16).read_volatile() }
+    }
+    /// Read 32-bit data.
+    #[inline]
+    pub fn read_u32(&self) -> u32 {
+        unsafe { self.0.get().read_volatile() }
+    }
+}
+
+/// Managed SPI structure with peripheral and pins.
+pub struct Spi<A: BaseAddress, const I: usize, PINS: Pins<I>> {
     spi: SPI<A>,
     pins: PINS,
 }
 
-impl<A: BaseAddress, PINS> embedded_hal::spi::SpiBusRead for Spi<A, PINS> {
+// Ref: rustsbi-d1 project
+impl<A: BaseAddress, const I: usize, PINS: Pins<I>> Spi<A, I, PINS> {
+    /// Create an SPI instance.
+    pub fn new<A1: BaseAddress>(
+        spi: SPI<A>,
+        pins: PINS,
+        mode: impl Into<Mode>,
+        freq: Hz,
+        clocks: &Clocks,
+        ccu: &CCU<A1>,
+    ) -> Self {
+        // 1. unwrap parameters
+        let (Hz(freq), Hz(psi)) = (freq, clocks.psi);
+        let (factor_n, factor_m) = {
+            let mut err = psi;
+            let (mut best_n, mut best_m) = (0, 0);
+            for m in 1u8..=16 {
+                for n in [1, 2, 4, 8] {
+                    let actual = psi / n / m as u32;
+                    if actual.abs_diff(freq) < err {
+                        err = actual.abs_diff(freq);
+                        (best_n, best_m) = (n, m);
+                    }
+                }
+            }
+            let factor_n = match best_n {
+                1 => FactorN::N1,
+                2 => FactorN::N2,
+                4 => FactorN::N4,
+                8 => FactorN::N8,
+                _ => unreachable!(),
+            };
+            let factor_m = best_m - 1;
+            (factor_n, factor_m)
+        };
+        // 2. init peripheral clocks
+        // clock and divider
+        unsafe { PINS::Clock::config(SpiClockSource::PllPeri1x, factor_m, factor_n, ccu) };
+        // de-assert reset
+        unsafe { PINS::Clock::reset(ccu) };
+        // 3. global configuration and soft reset
+        spi.gcr.write(
+            GlobalControl::default()
+                .set_enabled(true)
+                .set_master_mode()
+                .set_transmit_pause_enable(true)
+                .software_reset(),
+        );
+        while spi.gcr.read().is_software_reset_finished() {
+            core::hint::spin_loop();
+        }
+        // 4. configure work mode
+        spi.tcr
+            .write(TransferControl::default().set_work_mode(mode.into()));
+        // Finally, return ownership of this structure.
+        Spi { spi, pins }
+    }
+    /// Close SPI and release peripheral.
+    #[inline]
+    pub fn free<A1: BaseAddress>(self, ccu: &CCU<A1>) -> (SPI<A>, PINS) {
+        // clock is closed for self.clock_gate is dropped
+        unsafe { PINS::Clock::free(&ccu) };
+        (self.spi, self.pins)
+    }
+}
+
+/// Valid SPI pins.
+pub trait Pins<const I: usize> {
+    type Clock: ccu::ClockGate + ccu::ClockConfig<Source = SpiClockSource>;
+}
+
+impl<A: BaseAddress, const I: usize, PINS: Pins<I>> embedded_hal::spi::SpiBus for Spi<A, I, PINS> {
+    fn transfer(&mut self, read: &mut [u8], write: &[u8]) -> Result<(), Self::Error> {
+        assert!(read.len() + write.len() <= u32::MAX as usize);
+        self.spi.mbc.write((read.len() + write.len()) as u32);
+        self.spi.mtc.write(write.len() as u32);
+        let bcc = self
+            .spi
+            .bcc
+            .read()
+            .set_master_dummy_burst_counter(0)
+            .set_master_single_mode_transmit_counter(write.len() as u32);
+        self.spi.bcc.write(bcc);
+        self.spi
+            .tcr
+            .write(self.spi.tcr.read().start_burst_exchange());
+        for &word in write {
+            while self.spi.fsr.read().transmit_fifo_counter() > 63 {
+                core::hint::spin_loop();
+            }
+            self.spi.txd.write_u8(word)
+        }
+        for word in read {
+            while self.spi.fsr.read().receive_fifo_counter() == 0 {
+                core::hint::spin_loop();
+            }
+            *word = self.spi.rxd.read_u8()
+        }
+        Ok(())
+    }
+
+    fn transfer_in_place(&mut self, words: &mut [u8]) -> Result<(), Self::Error> {
+        assert!(words.len() * 2 <= u32::MAX as usize);
+        self.spi.mbc.write((words.len() * 2) as u32);
+        self.spi.mtc.write(words.len() as u32);
+        let bcc = self
+            .spi
+            .bcc
+            .read()
+            .set_master_dummy_burst_counter(0)
+            .set_master_single_mode_transmit_counter(words.len() as u32);
+        self.spi.bcc.write(bcc);
+        self.spi
+            .tcr
+            .write(self.spi.tcr.read().start_burst_exchange());
+        for &word in words.iter() {
+            while self.spi.fsr.read().transmit_fifo_counter() > 63 {
+                core::hint::spin_loop();
+            }
+            self.spi.txd.write_u8(word)
+        }
+        for word in words {
+            while self.spi.fsr.read().receive_fifo_counter() == 0 {
+                core::hint::spin_loop();
+            }
+            *word = self.spi.rxd.read_u8()
+        }
+        Ok(())
+    }
+}
+
+impl<A: BaseAddress, const I: usize, PINS: Pins<I>> embedded_hal::spi::SpiBusRead
+    for Spi<A, I, PINS>
+{
     fn read(&mut self, words: &mut [u8]) -> Result<(), Self::Error> {
+        assert!(words.len() <= u32::MAX as usize);
+        self.spi.mbc.write(words.len() as u32);
+        self.spi.mtc.write(0);
+        let bcc = self
+            .spi
+            .bcc
+            .read()
+            .set_master_dummy_burst_counter(0)
+            .set_master_single_mode_transmit_counter(0);
+        self.spi.bcc.write(bcc);
+        self.spi
+            .tcr
+            .write(self.spi.tcr.read().start_burst_exchange());
         for word in words {
-            while self.spi.fsr.read() & 0xff == 0 {
+            while self.spi.fsr.read().receive_fifo_counter() == 0 {
                 core::hint::spin_loop();
             }
-            *word = self.spi.rxd.read() as u8
+            *word = self.spi.rxd.read_u8()
         }
         Ok(())
     }
 }
 
-impl<A: BaseAddress, PINS> embedded_hal::spi::SpiBusWrite<u8> for Spi<A, PINS> {
+impl<A: BaseAddress, const I: usize, PINS: Pins<I>> embedded_hal::spi::SpiBusWrite<u8>
+    for Spi<A, I, PINS>
+{
     fn write(&mut self, words: &[u8]) -> Result<(), Self::Error> {
-        for word in words {
-            while (self.spi.fsr.read() >> 16) & 0xff >= 64 {
+        assert!(words.len() <= u32::MAX as usize);
+        self.spi.mbc.write(words.len() as u32);
+        self.spi.mtc.write(words.len() as u32);
+        let bcc = self
+            .spi
+            .bcc
+            .read()
+            .set_master_dummy_burst_counter(0)
+            .set_master_single_mode_transmit_counter(words.len() as u32);
+        self.spi.bcc.write(bcc);
+        self.spi
+            .tcr
+            .write(self.spi.tcr.read().start_burst_exchange());
+        for &word in words {
+            while self.spi.fsr.read().transmit_fifo_counter() > 63 {
                 core::hint::spin_loop();
             }
-            unsafe { self.spi.txd.write(*word as u32) }
+            self.spi.txd.write_u8(word)
         }
         Ok(())
     }
 }
 
-impl<A: BaseAddress, PINS> embedded_hal::spi::SpiBusFlush for Spi<A, PINS> {
+impl<A: BaseAddress, const I: usize, PINS: Pins<I>> embedded_hal::spi::SpiBusFlush
+    for Spi<A, I, PINS>
+{
     fn flush(&mut self) -> Result<(), Self::Error> {
-        while (self.spi.fsr.read() >> 16) & 0xff > 0 {
+        while !self.spi.tcr.read().burst_finished() {
             core::hint::spin_loop();
         }
         Ok(())
     }
 }
 
-impl<A: BaseAddress, PINS> embedded_hal::spi::ErrorType for Spi<A, PINS> {
+impl<A: BaseAddress, const I: usize, PINS: Pins<I>> embedded_hal::spi::ErrorType
+    for Spi<A, I, PINS>
+{
     type Error = embedded_hal::spi::ErrorKind;
 }
 

--- a/hal/aw-soc/src/uart.rs
+++ b/hal/aw-soc/src/uart.rs
@@ -249,10 +249,12 @@ impl<A: BaseAddress, const I: usize, PINS: Pins<I>> embedded_hal_nb::serial::Wri
 }
 
 /// UART Status Register.
+#[repr(transparent)]
 pub struct USR<R: Register>(UnsafeCell<R>);
 
 /// Status settings for current peripheral.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[repr(transparent)]
 pub struct UartStatus(u8);
 
 impl<R: uart16550::Register> USR<R> {


### PR DESCRIPTION
aw-soc: spi: TXD and RXD registers

aw-soc: spi: fsr fifo counter

aw-soc: spi: TCR and documents

aw-soc: update depenedency uart16550 to 0.0.1

aw-soc: spi: MBC, MTC and TCR

aw-soc: spi: spibus impl

aw-soc: spi: SPI_CLK and SPI_BGR

aw-soc: ccu: SPI peripheral reset

aw-soc: ccu: spi divide factors

aw-soc: only impl wafer/d1 if feature d1 enables

aw-soc: ccu: clock config for spi peripheral

aw-soc: spi: clock configuration

aw-soc: spi: global configuration

aw-soc: spi: create SPI instance

aw-soc: gpio: allow unused if no features enabled for macros