### PR TITLE
build(deps): upgrade dependencies

### DIFF
--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -10,14 +10,14 @@ repository.workspace = true
 [dependencies]
 ratatui = "0.26.1"
 crossterm = "0.27.0"
-sys-locale = "0.2.4"
-once_cell = "1.17.1"
-clap = { version = "4.1.11", features = ["cargo", "derive"] }
-toml_edit = { version = "0.19.7", features = ["serde"] }
-serde = { version = "1.0.158", features = ["derive"] }
+sys-locale = "0.3.1"
+once_cell = "1.19.0"
+clap = { version = "4.5.3", features = ["cargo", "derive"] }
+toml_edit = { version = "0.22.9", features = ["serde"] }
+serde = { version = "1.0.197", features = ["derive"] }
 serde_variant = "0.1.2"
-clap-verbosity-flag = "2.0.0"
+clap-verbosity-flag = "2.2.0"
 os-xtask-utils = "0.0.0"
-log = "0.4.17"
-byteorder = "1.4.3"
-env_logger = "0.10.0"
+log = "0.4.21"
+byteorder = "1.5.0"
+env_logger = "0.11.3"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -12,7 +12,7 @@ use clap_verbosity_flag::Verbosity;
 use log::error;
 use once_cell::sync::Lazy;
 use std::{error::Error, fs, io, path::Path};
-use toml_edit::{value, Document};
+use toml_edit::{value, DocumentMut};
 
 #[derive(Parser)]
 #[clap(name = "RustSBI Prototyping System")]
@@ -100,7 +100,7 @@ pub struct Config {
 
 fn save_app_to_string(app: &App, buf: &mut String) -> io::Result<()> {
     use serde_variant::to_variant_name;
-    let mut doc = buf.parse::<Document>().expect("invalid doc");
+    let mut doc = buf.parse::<DocumentMut>().expect("invalid doc");
     doc["locale"] = value(&app.locale);
     doc["bootstrap"] = value(to_variant_name(&app.bootstrap).unwrap());
     let StandardSbiEnabled {


### PR DESCRIPTION
build(deps): upgrade sys-locale to version 0.3.1
build(deps): upgrade once_cell to version 1.19.0
build(deps): upgrade clap to version 4.5.3
build(deps): upgrade toml_edit to version 0.22.9
build(deps): upgrade serde to version 1.0.197
build(deps): upgrade clap-verbosity-flag to version 2.2.0
build(deps): upgrade log to version 0.4.21
build(deps): upgrade byteorder to version 1.5.0
build(deps): upgrade env_logger to version 0.11.3